### PR TITLE
Add image loading css hook

### DIFF
--- a/addon/components/rotatable-image.js
+++ b/addon/components/rotatable-image.js
@@ -3,13 +3,24 @@ import DomElement from '../mixins/dom-element';
 
 export default Em.Component.extend(DomElement, {
   classNames: ['rotatable-image-container'],
+  classNameBindings: ['loading'],
   attributeBindings: ['style'],
+  loading: true,
 
   style: Em.computed('height', function() {
     var height = this.get('height');
 
     return 'line-height: ' + (height - 1) + 'px;';
   }),
+
+  handleLoaded: function() {
+    var component = this;
+    this.$().children('img').one('load', function() {
+      Em.run(function() {
+        component.set('loading', false);
+      });
+    });
+  }.on('didInsertElement'),
 
   actions: {
     onRotateImageRight: function() {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-data": "1.0.0-beta.12",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
-    "glob": "^4.0.5"
+    "glob": "^4.5.3"
   },
   "keywords": [
     "ember-addon"

--- a/tests/unit/components/rotatable-image-test.js
+++ b/tests/unit/components/rotatable-image-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import {
   moduleForComponent,
   test
@@ -18,4 +19,18 @@ test('it renders', function() {
   // appends the component to the page
   this.append();
   equal(component._state, 'inDOM');
+});
+
+test('css classes are updated when loading is set', function() {
+  expect(2);
+
+  var component = this.subject();
+
+  equal(this.$().attr('class'), 'ember-view rotatable-image-container loading');
+
+  Ember.run(function() {
+    component.set('loading', false);
+  });
+
+  equal(this.$().attr('class'), 'ember-view rotatable-image-container');
 });


### PR DESCRIPTION
Small update to add a 'loading' css class to the image container, so that apps using the add-on can optionally add loading styles. Also updated glob version to fix error when running tests with ember-cli.
